### PR TITLE
fix lowerprefix:UPPERCASHADDRESS

### DIFF
--- a/src/Address/AddressCreator.php
+++ b/src/Address/AddressCreator.php
@@ -99,7 +99,7 @@ class AddressCreator extends BaseAddressCreator
             }
 
             if (($base32Address = $this->readCashAddress(
-                sprintf("%s:%s", $network->getCashAddressPrefix(), $strAddress),
+                sprintf("%s:%s", $network->getCashAddressPrefix(), strtolower($strAddress)),
                 $network
             ))) {
                 return $base32Address;


### PR DESCRIPTION
`$addressCreator->fromString('QR2UTU6WXSH0AKZLP8JQCR72H6UYMA0A3CDPQTLV2Y', NetworkFactory::bitcoinCash());`
When use address which from QR scan without prefix,it will cause :
`throw new UnrecognizedAddressException("Address not recognized");`
Because bitcoincash:QR2UTU6WXSH0AKZLP8JQCR72H6UYMA0A3CDPQTLV2Y failed to decode address. AddressCreator.php Line 101.